### PR TITLE
Track cumulative all-time downloads with a persistent ledger

### DIFF
--- a/.github/workflows/crawl-and-publish.yml
+++ b/.github/workflows/crawl-and-publish.yml
@@ -124,6 +124,11 @@ jobs:
       run: uv run python scripts/download_stats.py
       continue-on-error: true
 
+    - name: Update download ledger
+      if: always() && hashFiles('data/raw/posts.json') != ''
+      run: uv run python scripts/download_ledger.py
+      continue-on-error: true
+
     - name: Upload to Hugging Face
       if: always() && hashFiles('data/raw/posts.json') != ''
       env:
@@ -155,7 +160,7 @@ jobs:
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add README.md ZENODO.json
+        git add README.md ZENODO.json download_ledger.json
         git diff --cached --quiet || git commit -m "Update dataset stats [skip ci]"
         git pull --rebase origin main
         git push

--- a/README.md
+++ b/README.md
@@ -102,12 +102,25 @@ If you use this dataset in your research, please cite:
 
 <!-- DOWNLOADS_START -->
 
+All-time downloads across platforms.
+
 | Platform | Downloads |
 |----------|-----------|
 | [Zenodo](https://doi.org/10.5281/zenodo.19470480) | 300 |
+| [Hugging Face](https://huggingface.co/datasets/takschdube/moltbook-dataset) | 3,370 |
 | [GitHub Releases](https://github.com/takschdube/moltbook-dataset/releases) | 599 |
 | [Kaggle](https://www.kaggle.com/datasets/takschdube/moltbook-dataset) | 9 |
-| **Total** | **908** |
+| **Total** | **4,278** |
+
+New downloads by month.
+
+| Month | Zenodo | Hugging Face | GitHub | Kaggle | Total |
+|-------|--------|--------------|--------|--------|-------|
+| 2026-04 | 0 | -- | 378 | 7 | 385 |
+| 2026-05 | 300 | -- | 203 | 2 | 505 |
+| 2026-06 | 0 | -- | 18 | 0 | 18 |
+
+*Monthly figures are differences of month-end cumulative counts. Hugging Face is tracked from its all-time baseline, so its per-month column begins once two checkpoints exist.*
 
 <!-- DOWNLOADS_END -->
 

--- a/download_ledger.json
+++ b/download_ledger.json
@@ -1,0 +1,59 @@
+{
+  "all_time": {
+    "zenodo": 300,
+    "github": 599,
+    "kaggle": 9,
+    "huggingface": 3370
+  },
+  "monthly": {
+    "2026-04": {
+      "zenodo": 0,
+      "github": 378,
+      "kaggle": 7
+    },
+    "2026-05": {
+      "zenodo": 300,
+      "github": 581,
+      "kaggle": 9
+    },
+    "2026-06": {
+      "zenodo": 300,
+      "github": 599,
+      "kaggle": 9
+    }
+  },
+  "monthly_new": {
+    "2026-04": {
+      "zenodo": 0,
+      "huggingface": null,
+      "github": 378,
+      "kaggle": 7,
+      "total": 385
+    },
+    "2026-05": {
+      "zenodo": 300,
+      "huggingface": null,
+      "github": 203,
+      "kaggle": 2,
+      "total": 505
+    },
+    "2026-06": {
+      "zenodo": 0,
+      "huggingface": null,
+      "github": 18,
+      "kaggle": 0,
+      "total": 18
+    }
+  },
+  "urls": {
+    "zenodo": "https://doi.org/10.5281/zenodo.19470480",
+    "huggingface": "https://huggingface.co/datasets/takschdube/moltbook-dataset",
+    "github": "https://github.com/takschdube/moltbook-dataset/releases",
+    "kaggle": "https://www.kaggle.com/datasets/takschdube/moltbook-dataset"
+  },
+  "total_all_time": 4278,
+  "updated_at": null,
+  "notes": {
+    "huggingface": "all-time baseline 3370 seeded from downloadsAllTime; monthly tracking starts at the next reading. History excluded because the README stored the rolling 30-day field."
+  }
+}

--- a/scripts/download_ledger.py
+++ b/scripts/download_ledger.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""
+Maintain a persistent, monotonic all-time download ledger.
+
+The per-platform APIs are inconsistent. Hugging Face's default `downloads`
+field is a rolling 30-day count, not a cumulative one, and any platform fetch
+can transiently fail. A naive sum therefore wobbles and undercounts. This
+ledger folds each fresh reading into a persistent high-water mark per platform
+(carry forward on a failed read, never drop to zero) and checkpoints the
+cumulative totals at each month boundary, so a month's downloads are a simple
+difference of two checkpoints.
+
+Cumulative, all-time inputs expected per platform:
+  zenodo       sum of stats.downloads across versions
+  huggingface  downloadsAllTime   (NOT the rolling `downloads` field)
+  github       sum of asset.download_count across releases
+  kaggle       totalDownloads
+
+Usage:
+  uv run python scripts/download_ledger.py
+      Fold data/derived/download_stats.json into the ledger.
+
+  uv run python scripts/download_ledger.py --backfill-git --hf-alltime 3370
+      Rebuild the monthly history of the cumulative platforms from the git log
+      of README.md, then seed the Hugging Face all-time baseline.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+DERIVED_DIR = Path("data/derived")
+# data/ is gitignored and rebuilt each CI run, so the ledger lives at the repo
+# root (like ZENODO.json) where it persists across runs.
+LEDGER_PATH = Path("download_ledger.json")
+STATS_PATH = DERIVED_DIR / "download_stats.json"
+
+PLATFORMS = ["zenodo", "huggingface", "github", "kaggle"]
+
+
+def load_ledger():
+    if LEDGER_PATH.exists():
+        with open(LEDGER_PATH) as f:
+            return json.load(f)
+    return {"all_time": {}, "monthly": {}, "monthly_new": {}, "urls": {},
+            "total_all_time": 0, "updated_at": None, "notes": {}}
+
+
+def save_ledger(ledger):
+    tmp = str(LEDGER_PATH) + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(ledger, f, indent=2)
+    Path(tmp).replace(LEDGER_PATH)
+
+
+def month_of(iso):
+    return iso[:7]
+
+
+def fold_reading(ledger, reading, month):
+    """Fold one {platform: count_or_None} reading into the ledger.
+
+    Monotonic high-water mark per platform; a None (failed fetch) carries the
+    last known value forward instead of dropping the platform to zero. The
+    month checkpoint records the cumulative all-time per platform as of the
+    latest reading seen in that month.
+    """
+    all_time = ledger["all_time"]
+    for p in PLATFORMS:
+        value = reading.get(p)
+        if value is not None:
+            all_time[p] = max(all_time.get(p, 0), int(value))
+    checkpoint = ledger["monthly"].setdefault(month, {})
+    for p in PLATFORMS:
+        if p in all_time:
+            checkpoint[p] = all_time[p]
+    ledger["total_all_time"] = sum(all_time.values())
+
+
+def recompute_monthly_new(ledger):
+    """Derive per-month new downloads from consecutive month checkpoints.
+
+    A platform contributes to a month only when both that month and the prior
+    month have a real checkpoint for it, so a platform seeded as a baseline
+    (e.g. Hugging Face) does not show a phantom spike in its first month.
+    """
+    months = sorted(ledger["monthly"])
+    monthly_new = {}
+    for i, m in enumerate(months):
+        prev = ledger["monthly"][months[i - 1]] if i > 0 else {}
+        cur = ledger["monthly"][m]
+        delta = {}
+        for p in PLATFORMS:
+            if p in cur and p in prev:
+                delta[p] = cur[p] - prev[p]
+            elif p in cur and i == 0:
+                delta[p] = cur[p]  # first tracked month = baseline-in
+            else:
+                delta[p] = None
+        delta["total"] = sum(v for v in delta.values() if v is not None)
+        monthly_new[m] = delta
+    ledger["monthly_new"] = monthly_new
+
+
+# --- backfill from the git history of README.md -----------------------------
+
+LABELS = {"zenodo": "Zenodo", "huggingface": "Hugging Face",
+          "github": "GitHub", "kaggle": "Kaggle"}
+
+
+def _downloads_block(readme):
+    m = re.search(r"DOWNLOADS_START(.*?)DOWNLOADS_END", readme, re.S)
+    return m.group(1) if m else None
+
+
+def parse_counts(readme):
+    block = _downloads_block(readme)
+    if block is None:
+        return None
+    out = {}
+    for key, label in LABELS.items():
+        mm = re.search(rf"\|\s*\[?{label}[^|]*\]?[^|]*\|\s*([\d,]+)\s*\|", block)
+        out[key] = int(mm.group(1).replace(",", "")) if mm else None
+    return out
+
+
+def parse_urls(readme):
+    block = _downloads_block(readme)
+    urls = {}
+    if block is None:
+        return urls
+    for key, label in LABELS.items():
+        mm = re.search(rf"\[{label}[^\]]*\]\((https?://[^)]+)\)", block)
+        if mm:
+            urls[key] = mm.group(1)
+    return urls
+
+
+def backfill_from_git(ledger, hf_alltime):
+    log = subprocess.run(
+        ["git", "log", "--reverse", "--format=%H|%cI", "--", "README.md"],
+        capture_output=True, text=True,
+    ).stdout.splitlines()
+
+    snapshots = 0
+    for line in log:
+        h, iso = line.split("|")
+        readme = subprocess.run(
+            ["git", "show", f"{h}:README.md"], capture_output=True, text=True
+        ).stdout
+        counts = parse_counts(readme)
+        if counts is None:
+            continue
+        # Accumulate URLs across snapshots; a later snapshot that drops a row
+        # (e.g. a failed Hugging Face fetch) keeps the earlier URL.
+        ledger["urls"].update(parse_urls(readme))
+        # Cumulative platforms only. Hugging Face is rolling-30 in history and
+        # is not cumulative, so it is excluded here and seeded separately below.
+        reading = {p: counts.get(p) for p in ("zenodo", "github", "kaggle")}
+        fold_reading(ledger, reading, month_of(iso))
+        snapshots += 1
+
+    if hf_alltime is not None:
+        ledger["all_time"]["huggingface"] = int(hf_alltime)
+        ledger["total_all_time"] = sum(ledger["all_time"].values())
+        ledger["notes"]["huggingface"] = (
+            f"all-time baseline {int(hf_alltime)} seeded from downloadsAllTime; "
+            "monthly tracking starts at the next reading. History excluded "
+            "because the README stored the rolling 30-day field."
+        )
+    recompute_monthly_new(ledger)
+    return snapshots
+
+
+# --- forward path: fold today's download_stats.json -------------------------
+
+def fold_stats_json(ledger):
+    if not STATS_PATH.exists():
+        raise SystemExit(f"{STATS_PATH} not found; run download_stats.py first")
+    with open(STATS_PATH) as f:
+        stats = json.load(f)
+    platforms = stats.get("platforms", {})
+    reading = {}
+    for p in PLATFORMS:
+        if p in platforms:
+            reading[p] = platforms[p].get("downloads")
+            if platforms[p].get("url"):
+                ledger["urls"][p] = platforms[p]["url"]
+        else:
+            reading[p] = None
+    month = month_of(stats.get("updated_at") or datetime.now(timezone.utc).isoformat())
+    fold_reading(ledger, reading, month)
+    recompute_monthly_new(ledger)
+    return reading
+
+
+def fmt(n):
+    return "      --" if n is None else f"{n:>8,}"
+
+
+def print_report(ledger):
+    at = ledger["all_time"]
+    print("All-time downloads")
+    print("-" * 34)
+    for p in PLATFORMS:
+        print(f"  {LABELS[p]:<14} {at.get(p, 0):>10,}")
+    print(f"  {'Total':<14} {ledger['total_all_time']:>10,}")
+    print("\nNew downloads by month")
+    print("-" * 60)
+    print(f"  {'month':<9}" + "".join(f"{LABELS[p][:8]:>9}" for p in PLATFORMS) + f"{'total':>9}")
+    for m in sorted(ledger["monthly_new"]):
+        row = ledger["monthly_new"][m]
+        print(f"  {m:<9}" + "".join(fmt(row.get(p)) + " " for p in PLATFORMS) + fmt(row.get("total")))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--backfill-git", action="store_true",
+                    help="rebuild monthly history from the README git log")
+    ap.add_argument("--hf-alltime", type=int, default=None,
+                    help="Hugging Face downloadsAllTime baseline to seed")
+    args = ap.parse_args()
+
+    ledger = load_ledger()
+    if args.backfill_git:
+        n = backfill_from_git(ledger, args.hf_alltime)
+        print(f"Backfilled {n} snapshots from git history\n")
+    else:
+        reading = fold_stats_json(ledger)
+        ledger["updated_at"] = datetime.now(timezone.utc).isoformat()
+        print(f"Folded reading: {reading}\n")
+
+    save_ledger(ledger)
+    print_report(ledger)
+    print(f"\nSaved to {LEDGER_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/download_stats.py
+++ b/scripts/download_stats.py
@@ -67,17 +67,34 @@ def get_zenodo_downloads():
 
 
 def get_hf_downloads():
-    """Get download count from Hugging Face."""
+    """Get cumulative all-time download count from Hugging Face.
+
+    The default `downloads` field is a rolling 30-day count; `downloadsAllTime`
+    is the cumulative figure and is only returned when explicitly expanded.
+    A token is sent when available: anonymous Hub requests from shared CI IPs
+    are the most common cause of the transient 429s that drop this row.
+    """
+    token = (
+        os.getenv("HF_TOKEN")
+        or os.getenv("HUGGINGFACE_TOKEN")
+        or os.getenv("HUGGINGFACE_HUB_TOKEN")
+    )
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
     resp = requests.get(
         f"https://huggingface.co/api/datasets/{HF_REPO}",
+        params={"expand[]": "downloadsAllTime"},
+        headers=headers,
         timeout=30,
     )
     if resp.status_code != 200:
         return None
 
     data = resp.json()
+    downloads = data.get("downloadsAllTime")
+    if downloads is None:
+        downloads = data.get("downloads", 0)
     return {
-        "downloads": data.get("downloads", 0),
+        "downloads": downloads,
         "url": f"https://huggingface.co/datasets/{HF_REPO}",
     }
 

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -209,8 +209,76 @@ def build_citation_section():
     return "\n".join(lines)
 
 
+LEDGER_PATH = Path("download_ledger.json")
+
+PLATFORM_LABELS = {
+    "zenodo": "Zenodo",
+    "huggingface": "Hugging Face",
+    "github": "GitHub Releases",
+    "kaggle": "Kaggle",
+}
+PLATFORM_ORDER = ["zenodo", "huggingface", "github", "kaggle"]
+
+
 def build_downloads_section():
-    """Build downloads table from download_stats.json."""
+    """Build the downloads section, preferring the persistent ledger."""
+    if LEDGER_PATH.exists():
+        with open(LEDGER_PATH) as f:
+            return _downloads_from_ledger(json.load(f))
+    return _downloads_from_stats()
+
+
+def _downloads_from_ledger(ledger):
+    """All-time table plus a per-month breakdown, from download_ledger.json."""
+    all_time = ledger.get("all_time", {})
+    if not all_time:
+        return None
+    urls = ledger.get("urls", {})
+    total = ledger.get("total_all_time", sum(all_time.values()))
+
+    lines = [
+        DOWNLOADS_START,
+        "",
+        "All-time downloads across platforms.",
+        "",
+        "| Platform | Downloads |",
+        "|----------|-----------|",
+    ]
+    for key in PLATFORM_ORDER:
+        if key in all_time:
+            label = PLATFORM_LABELS.get(key, key)
+            url = urls.get(key)
+            cell = f"[{label}]({url})" if url else label
+            lines.append(f"| {cell} | {format_number(all_time[key])} |")
+    lines.append(f"| **Total** | **{format_number(total)}** |")
+
+    monthly_new = ledger.get("monthly_new", {})
+    if monthly_new:
+        lines += [
+            "",
+            "New downloads by month.",
+            "",
+            "| Month | Zenodo | Hugging Face | GitHub | Kaggle | Total |",
+            "|-------|--------|--------------|--------|--------|-------|",
+        ]
+        for month in sorted(monthly_new):
+            row = monthly_new[month]
+            cells = [month] + [format_number(row.get(p)) for p in PLATFORM_ORDER]
+            cells.append(format_number(row.get("total")))
+            lines.append("| " + " | ".join(cells) + " |")
+        lines += [
+            "",
+            "*Monthly figures are differences of month-end cumulative counts. "
+            "Hugging Face is tracked from its all-time baseline, so its per-month "
+            "column begins once two checkpoints exist.*",
+        ]
+
+    lines += ["", DOWNLOADS_END]
+    return "\n".join(lines)
+
+
+def _downloads_from_stats():
+    """Fallback when no ledger exists: the volatile download_stats.json snapshot."""
     stats_path = DERIVED_DIR / "download_stats.json"
     if not stats_path.exists():
         return None
@@ -224,13 +292,6 @@ def build_downloads_section():
     if not platforms:
         return None
 
-    platform_labels = {
-        "zenodo": "Zenodo",
-        "huggingface": "Hugging Face",
-        "github": "GitHub Releases",
-        "kaggle": "Kaggle",
-    }
-
     lines = [
         DOWNLOADS_START,
         "",
@@ -238,11 +299,11 @@ def build_downloads_section():
         "|----------|-----------|",
     ]
 
-    for key in ["zenodo", "huggingface", "github", "kaggle"]:
+    for key in PLATFORM_ORDER:
         if key in platforms:
             count = format_number(platforms[key].get("downloads"))
             url = platforms[key].get("url", "")
-            label = platform_labels.get(key, key)
+            label = PLATFORM_LABELS.get(key, key)
             lines.append(f"| [{label}]({url}) | {count} |")
 
     lines.append(f"| **Total** | **{format_number(total)}** |")


### PR DESCRIPTION
## Summary

The README Downloads total was computed by summing a fresh reading from four platform APIs on every run. Two properties of that approach made the figure unreliable. A failed fetch dropped a platform to zero, and the Hugging Face value used the rolling 30-day `downloads` field rather than a cumulative count. The headline therefore halved whenever the Hugging Face request was throttled, and undercounted Hugging Face the rest of the time. Across the 222 README snapshots in git history, the Hugging Face row is missing in 3, with the misses clustered in the last day.

## Root cause

`get_hf_downloads()` made an unauthenticated request and returned `None` on any non-200 response, and `update_readme.py` dropped both the row and its contribution to the total when a platform was absent. Separately, the Hugging Face `downloads` field is a rolling 30-day window; `downloadsAllTime` is the cumulative figure and was not being read. Against the live API, `downloadsAllTime` is 3,370 while the rolling field is near 1,100.

## Changes

- `scripts/download_stats.py`: the Hugging Face fetch requests `downloadsAllTime` and sends a token when one is present, falling back to the rolling field only if the cumulative value is absent.
- `scripts/download_ledger.py` (new): a persistent ledger at the repo root. Each run folds a reading into a per-platform high-water mark, a failed fetch carries the last value forward, and month-end checkpoints make a month's downloads a difference of two checkpoints.
- `scripts/update_readme.py`: the Downloads section is driven by the ledger, showing all-time totals and a per-month breakdown, with a fallback to the previous snapshot behaviour when no ledger exists.
- `.github/workflows/crawl-and-publish.yml`: runs the ledger step after stats collection and commits `download_ledger.json`.
- `download_ledger.json`: seeded by replaying the 222 README snapshots for the cumulative platforms, with the Hugging Face all-time baseline set from `downloadsAllTime`.

## Verification

- Backfill from git history yields an all-time total of 4,278 (Zenodo 300, Hugging Face 3,370, GitHub 599, Kaggle 9).
- The patched Hugging Face fetch returns 3,370 against the live API.
- Folding a reading with a missing Hugging Face value holds the total instead of halving it; an under-reporting platform stays at its high-water mark.
- The three cumulative platforms reconstruct cleanly by month: April +385 (baseline, tracking began 2026-04-08), May +505, June +18 to date. Hugging Face per-month begins forward from the baseline because historical snapshots stored only the rolling field.

## Notes

The ledger lives at the repo root because `data/` is gitignored and rebuilt each run. The all-time figure is monotonic per platform by design; a provider revising a count downward will not lower the headline. No issue is linked; opened directly per request.
