### PR TITLE
fix: correct Zenodo download counts (100x inflation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,22 +123,22 @@ All-time downloads across platforms.
 
 | Platform | Downloads |
 |----------|-----------|
-| [Zenodo](https://doi.org/10.5281/zenodo.19470480) | 10,800 |
+| [Zenodo](https://doi.org/10.5281/zenodo.19470480) | 108 |
 | [Hugging Face](https://huggingface.co/datasets/takschdube/moltbook-dataset) | 4,740 |
 | [GitHub Releases](https://github.com/takschdube/moltbook-dataset/releases) | 844 |
 | [Kaggle](https://www.kaggle.com/datasets/takschdube/moltbook-dataset) | 112 |
-| **Total** | **16,496** |
+| **Total** | **5,804** |
 
 New downloads by month.
 
 | Month | Zenodo | Hugging Face | GitHub | Kaggle | Total |
 |-------|--------|--------------|--------|--------|-------|
 | 2026-04 | 0 | -- | 378 | 7 | 385 |
-| 2026-05 | 300 | -- | 203 | 2 | 505 |
-| 2026-06 | 9,012 | -- | 149 | 4 | 9,165 |
-| 2026-07 | 1,488 | 602 | 114 | 99 | 2,303 |
+| 2026-05 | 3 | -- | 203 | 2 | 208 |
+| 2026-06 | 94 | -- | 149 | 4 | 247 |
+| 2026-07 | 11 | 602 | 114 | 99 | 826 |
 
-*Monthly figures are differences of month-end cumulative counts. Hugging Face is tracked from its all-time baseline, so its per-month column begins once two checkpoints exist.*
+*Monthly figures are differences of month-end cumulative counts. Hugging Face is tracked from its all-time baseline, so its per-month column begins once two checkpoints exist. GitHub counts include the pipeline's own release downloads (each run restores the previous database from the latest release).*
 
 <!-- DOWNLOADS_END -->
 

--- a/download_ledger.json
+++ b/download_ledger.json
@@ -1,6 +1,6 @@
 {
   "all_time": {
-    "zenodo": 10800,
+    "zenodo": 108,
     "github": 844,
     "kaggle": 112,
     "huggingface": 4740
@@ -12,18 +12,18 @@
       "kaggle": 7
     },
     "2026-05": {
-      "zenodo": 300,
+      "zenodo": 3,
       "github": 581,
       "kaggle": 9
     },
     "2026-06": {
-      "zenodo": 9312,
+      "zenodo": 97,
       "github": 730,
       "kaggle": 13,
       "huggingface": 4138
     },
     "2026-07": {
-      "zenodo": 10800,
+      "zenodo": 108,
       "huggingface": 4740,
       "github": 844,
       "kaggle": 112
@@ -38,25 +38,25 @@
       "total": 385
     },
     "2026-05": {
-      "zenodo": 300,
+      "zenodo": 3,
       "huggingface": null,
       "github": 203,
       "kaggle": 2,
-      "total": 505
+      "total": 208
     },
     "2026-06": {
-      "zenodo": 9012,
+      "zenodo": 94,
       "huggingface": null,
       "github": 149,
       "kaggle": 4,
-      "total": 9165
+      "total": 247
     },
     "2026-07": {
-      "zenodo": 1488,
+      "zenodo": 11,
       "huggingface": 602,
       "github": 114,
       "kaggle": 99,
-      "total": 2303
+      "total": 826
     }
   },
   "urls": {
@@ -65,9 +65,11 @@
     "github": "https://github.com/takschdube/moltbook-dataset/releases",
     "kaggle": "https://www.kaggle.com/datasets/takschdube/moltbook-dataset"
   },
-  "total_all_time": 16496,
+  "total_all_time": 5804,
   "updated_at": "2026-07-17T12:29:28.474635+00:00",
   "notes": {
-    "huggingface": "all-time baseline 3370 seeded from downloadsAllTime; monthly tracking starts at the next reading. History excluded because the README stored the rolling 30-day field."
+    "huggingface": "all-time baseline 3370 seeded from downloadsAllTime; monthly tracking starts at the next reading. History excluded because the README stored the rolling 30-day field.",
+    "zenodo": "2026-07-17 correction: readings before this date summed the all-versions aggregate once per version record returned by the search API, inflating counts by the page size (about 100x). History reconstructed from the known version counts: month-end aggregates 0 (Apr), 3 (May), 97 (Jun). Counts from here on are the true all-versions aggregate.",
+    "github": "Includes the pipeline's own restore downloads (the workflow fetches the previous release database every run, 4-5x/day). Organic share is small."
   }
 }

--- a/scripts/download_stats.py
+++ b/scripts/download_stats.py
@@ -36,32 +36,33 @@ def load_zenodo_json():
 
 
 def get_zenodo_downloads():
-    """Get total downloads across all Zenodo versions."""
+    """Get total downloads across all Zenodo versions.
+
+    A record's plain stats fields (downloads, views, ...) are already the
+    all-versions aggregate for the whole concept; the per-version figures are
+    the version_* fields. Summing stats.downloads across version records
+    therefore multiplies the aggregate by the page size (the 10,800 bug of
+    2026-07), so read the aggregate once from the concept record instead.
+    """
     record = load_zenodo_json()
     if not record:
         return None
 
     concept_id = record["concept_record_id"]
-    token = os.getenv("ZENODO_TOKEN")
-    headers = {"Authorization": f"Bearer {token}"} if token else {}
 
-    # Get all versions
+    # The concept id redirects to the latest published version
     resp = requests.get(
-        f"https://zenodo.org/api/records/?q=conceptrecid:{concept_id}&all_versions=true&size=100",
-        headers=headers,
+        f"https://zenodo.org/api/records/{concept_id}",
         timeout=30,
     )
     if resp.status_code != 200:
         return None
 
-    hits = resp.json().get("hits", {}).get("hits", [])
-    total_downloads = sum(h.get("stats", {}).get("downloads", 0) for h in hits)
-    total_views = sum(h.get("stats", {}).get("views", 0) for h in hits)
-
+    stats = resp.json().get("stats", {})
     return {
-        "downloads": total_downloads,
-        "views": total_views,
-        "versions": len(hits),
+        "downloads": stats.get("downloads", 0),
+        "unique_downloads": stats.get("unique_downloads", 0),
+        "views": stats.get("views", 0),
         "url": record["url"],
     }
 

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -270,7 +270,9 @@ def _downloads_from_ledger(ledger):
             "",
             "*Monthly figures are differences of month-end cumulative counts. "
             "Hugging Face is tracked from its all-time baseline, so its per-month "
-            "column begins once two checkpoints exist.*",
+            "column begins once two checkpoints exist. GitHub counts include the "
+            "pipeline's own release downloads (each run restores the previous "
+            "database from the latest release).*",
         ]
 
     lines += ["", DOWNLOADS_END]


### PR DESCRIPTION
Closes #12.

Root cause: a record's plain stats fields in Zenodo's API are the all-versions aggregate; per-version numbers live in the version_* fields. Summing stats.downloads over up to 100 version records multiplied the true aggregate by the page size, producing 10,800 against a real all-time count of 108 (107 unique users, 778 views).

Changes:
- download_stats.py reads the aggregate once via the concept record redirect instead of summing search hits. The call is anonymous; the endpoint is public.
- download_ledger.json: zenodo all-time reset to 108; month checkpoints reconstructed from known version counts (0 Apr, 3 May, 97 Jun, 108 Jul). Monthly deltas recomputed: 0, 3, 94, 11. Correction documented in the ledger notes.
- README downloads table regenerated from the repaired ledger (total 16,496 to 5,804).
- update_readme.py footnote notes that GitHub counts include the workflow's own restore downloads (508 of 845 asset downloads are the db.zst restore artifact).

Verification: the fixed getter run against the live API returns 108, matching the record page. Other platforms audited: Hugging Face 4,740 confirmed live via downloadsAllTime; Kaggle 112 is Kaggle's own totalDownloads counter; GitHub 845 verified by per-asset breakdown.