### PR TITLE
feat: engagement time series in the database, daily Zenodo cadence

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ New downloads by month.
 | `posts_full.json` | Posts with full threaded comment trees |
 | `platform_stats.json` | Platform-wide aggregate counts |
 | `metadata.json` | Crawl history and provenance |
+| `post_metrics_recent.csv` | Engagement time series (last 90 days): one row per post per crawl cycle with upvotes, downvotes, score, comment_count, hot_score, is_deleted |
+
+The JSON files hold the latest observed state of each post. The engagement
+trajectory over time lives in the `post_metrics_history` table of
+`moltbook.db` (shipped with every GitHub release as `moltbook.db.zst` and
+archived on Zenodo); `post_metrics_recent.csv` is a bounded 90-day window of
+the same series for convenience. History collection began 2026-07-17;
+earlier trajectories can be reconstructed from the archived snapshots
+(Zenodo versions and the Hugging Face mirror's git history).
 
 ### Derived data (`data/derived/`) — computed from raw
 

--- a/moltbook_crawler.py
+++ b/moltbook_crawler.py
@@ -11,6 +11,7 @@ Usage:
 """
 
 import requests
+import csv
 import json
 import sqlite3
 import time
@@ -194,8 +195,43 @@ def init_db():
             PRIMARY KEY (name, sort)
         )
     """)
+    # Append-only engagement time series. posts/posts_full hold latest state
+    # only (INSERT OR REPLACE), so without this table the trajectory of
+    # mutable fields exists nowhere in the database. One row per post per
+    # crawl cycle, first sighting in a cycle wins.
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS post_metrics_history (
+            post_id TEXT NOT NULL,
+            observed_at TEXT NOT NULL,
+            upvotes INTEGER,
+            downvotes INTEGER,
+            score INTEGER,
+            comment_count INTEGER,
+            hot_score REAL,
+            is_deleted INTEGER,
+            PRIMARY KEY (post_id, observed_at)
+        )
+    """)
     db.commit()
     return db
+
+def store_post(db, post):
+    """Write a post's latest state and append its engagement observation."""
+    db.execute(
+        "INSERT OR REPLACE INTO posts (id, data) VALUES (?, ?)",
+        (post["id"], json.dumps(post, ensure_ascii=False)),
+    )
+    observed = (_start_time or datetime.now(timezone.utc)).isoformat()
+    db.execute(
+        """
+        INSERT OR IGNORE INTO post_metrics_history
+        (post_id, observed_at, upvotes, downvotes, score, comment_count, hot_score, is_deleted)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (post["id"], observed, post.get("upvotes"), post.get("downvotes"),
+         post.get("score"), post.get("comment_count"), post.get("hot_score"),
+         1 if post.get("is_deleted") else 0),
+    )
 
 def migrate_json_to_db(db):
     """One-time migration: import existing JSON files into SQLite."""
@@ -231,6 +267,30 @@ def migrate_json_to_db(db):
                     db.commit()
         db.commit()
         logger.log(f"Imported {imported} full posts")
+
+def export_metrics_csv(db, days=90):
+    """Export the last N days of engagement history to a bounded CSV.
+
+    The full series ships in the moltbook.db release asset; bounding the CSV
+    keeps the zip and mirror uploads from growing without limit.
+    """
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+    filepath = RAW_DIR / "post_metrics_recent.csv"
+    columns = ["post_id", "observed_at", "upvotes", "downvotes", "score",
+               "comment_count", "hot_score", "is_deleted"]
+    with open(filepath, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(columns)
+        rows = db.execute(
+            f"SELECT {', '.join(columns)} FROM post_metrics_history "
+            "WHERE observed_at >= ? ORDER BY observed_at, post_id",
+            (cutoff,),
+        )
+        count = 0
+        for row in rows:
+            writer.writerow(row)
+            count += 1
+    logger.log(f"Exported {count} metric observations (last {days} days) to {filepath.name}")
 
 def export_posts_json(db):
     """Stream posts table to data/raw/posts.json (constant memory)."""
@@ -387,10 +447,7 @@ def fetch_posts_incremental(db, since=None):
                         updated_ids.add(post["id"])
                         logger.stats["updated_posts"] += 1
 
-            db.execute(
-                "INSERT OR REPLACE INTO posts (id, data) VALUES (?, ?)",
-                (post["id"], json.dumps(post, ensure_ascii=False)),
-            )
+            store_post(db, post)
 
         fetched += len(posts)
         pbar.update(len(posts))
@@ -653,10 +710,7 @@ def fetch_submolt_backfill(db, submolts):
                 if post["id"] not in existing_ids:
                     existing_ids.add(post["id"])
                     new_ids.add(post["id"])
-                db.execute(
-                    "INSERT OR REPLACE INTO posts (id, data) VALUES (?, ?)",
-                    (post["id"], json.dumps(post, ensure_ascii=False)),
-                )
+                store_post(db, post)
 
             # Update progress
             db.execute(
@@ -727,10 +781,7 @@ def fetch_all_posts(db):
                 logger.stats["new_posts"] += 1
                 new_in_batch += 1
 
-            db.execute(
-                "INSERT OR REPLACE INTO posts (id, data) VALUES (?, ?)",
-                (post["id"], json.dumps(post, ensure_ascii=False)),
-            )
+            store_post(db, post)
 
         fetched += len(posts)
         pbar.update(len(posts))
@@ -949,10 +1000,7 @@ def crawl(mode="incremental"):
         hot_ids, hot_new_posts = fetch_hot_posts(existing_post_ids)
         for p in hot_new_posts:
             if p["id"] not in existing_post_ids:
-                db.execute(
-                    "INSERT OR REPLACE INTO posts (id, data) VALUES (?, ?)",
-                    (p["id"], json.dumps(p, ensure_ascii=False)),
-                )
+                store_post(db, p)
                 existing_post_ids.add(p["id"])
                 new_ids.add(p["id"])
         db.commit()
@@ -978,6 +1026,7 @@ def crawl(mode="incremental"):
     logger.log("Exporting JSON files...")
     export_posts_json(db)
     export_posts_full_json(db)
+    export_metrics_csv(db)
 
     # Save metadata
     crawl_info = {

--- a/scripts/package_release.py
+++ b/scripts/package_release.py
@@ -64,7 +64,7 @@ def load_data():
     for directory, prefix in [(RAW_DIR, "raw"), (DERIVED_DIR, "derived")]:
         if not directory.exists():
             continue
-        for path in sorted(directory.glob("*.json")):
+        for path in sorted(list(directory.glob("*.json")) + list(directory.glob("*.csv"))):
             name = f"{prefix}/{path.name}"
             size_bytes = path.stat().st_size
             files[name] = {

--- a/scripts/upload_to_huggingface.py
+++ b/scripts/upload_to_huggingface.py
@@ -34,11 +34,11 @@ def main():
         print(f"Error creating repo: {e}")
         return
 
-    # Upload all JSON files from both directories
+    # Upload all JSON and CSV files from both directories
     for directory, prefix in [(RAW_DIR, "raw"), (DERIVED_DIR, "derived")]:
         if not directory.exists():
             continue
-        for filepath in sorted(directory.glob("*.json")):
+        for filepath in sorted(list(directory.glob("*.json")) + list(directory.glob("*.csv"))):
             path_in_repo = f"{prefix}/{filepath.name}"
             try:
                 api.upload_file(

--- a/scripts/upload_to_zenodo.py
+++ b/scripts/upload_to_zenodo.py
@@ -14,8 +14,9 @@ Usage:
 
 import json
 import os
+import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import requests
@@ -184,13 +185,27 @@ def upload_file(bucket_url, filepath, name):
 
 
 def upload_files(bucket_url):
-    """Upload the release zip (or individual files if no zip exists)."""
-    # Prefer the release zip — single file, includes everything
+    """Upload the release zip plus the cumulative database.
+
+    The zip holds the latest-state JSON exports; the database additionally
+    carries the full post_metrics_history time series, so archiving both
+    keeps the longitudinal record complete on Zenodo.
+    """
     zips = sorted(RELEASES_DIR.glob("moltbook-dataset-*.zip")) if RELEASES_DIR.exists() else []
     if zips:
         latest_zip = zips[-1]
         print(f"Uploading {latest_zip.name}...")
-        return upload_file(bucket_url, latest_zip, latest_zip.name)
+        ok = upload_file(bucket_url, latest_zip, latest_zip.name)
+
+        db_zst = Path("/tmp/moltbook.db.zst")  # produced by the release step
+        db_raw = RAW_DIR / "moltbook.db"
+        if not db_zst.exists() and db_raw.exists():
+            subprocess.run(
+                ["zstd", "-3", "-f", str(db_raw), "-o", str(db_zst)], check=False
+            )
+        if db_zst.exists():
+            ok = upload_file(bucket_url, db_zst, "moltbook.db.zst") and ok
+        return ok
 
     # Fallback: upload individual files
     print("No release zip found, uploading individual files...")
@@ -220,6 +235,17 @@ def main():
     if not ZENODO_TOKEN:
         print("ZENODO_TOKEN not set, skipping Zenodo upload")
         return
+
+    # Daily cadence: the crawl runs every 6 hours, but 4-5 DOI versions a day
+    # is outside what Zenodo versioning is for and nobody cites an hour.
+    # 20h threshold so normal cron drift never skips a day.
+    record = load_zenodo_json()
+    if record and record.get("updated_at"):
+        last = datetime.fromisoformat(record["updated_at"])
+        age = datetime.now(timezone.utc) - last
+        if age < timedelta(hours=20):
+            print(f"Last publish {record['updated_at']} ({age} ago); daily cadence, skipping")
+            return
 
     print("=" * 60)
     print("Zenodo Upload")


### PR DESCRIPTION
Closes #17.

Changes:
- moltbook_crawler.py: post_metrics_history table (post_id, observed_at, upvotes, downvotes, score, comment_count, hot_score, is_deleted; PK dedupes repeat sightings within a cycle). All four post write sites now route through a single store_post helper that records the observation alongside the state write. export_metrics_csv writes a 90-day window to raw/post_metrics_recent.csv; the full series stays in the database, which ships with every release and now also goes to Zenodo.
- package_release.py and upload_to_huggingface.py include CSV files from the data directories.
- upload_to_zenodo.py: skip publishing when the last publish is under 20 hours old (daily DOI cadence), and upload moltbook.db.zst alongside the zip so the archival layer carries the full longitudinal record.
- README documents the new series and where each granularity lives.

Verification: synthetic two-cycle run against a temp database produces two history rows with first-sighting-wins dedup, replaces latest state correctly, and exports the CSV; the cadence guard skips on a fresh ZENODO.json. py_compile passes on all touched scripts. Table creation is IF NOT EXISTS, so the restored production database migrates on first run.