### PR TITLE
fix: packaging crashed json-parsing the metrics CSV

### DIFF
--- a/scripts/package_release.py
+++ b/scripts/package_release.py
@@ -73,6 +73,12 @@ def load_data():
                 "size_mb": round(size_bytes / 1024 / 1024, 2),
             }
 
+            if path.suffix == ".csv":
+                # CSVs are packaged but not JSON-parsed; count data rows
+                with open(path, "r", encoding="utf-8") as f:
+                    files[name]["count"] = max(0, sum(1 for _ in f) - 1)
+                continue
+
             if path.name in STREAM_FILES and prefix == "raw":
                 # Stream large files
                 print(f"  Streaming {path.name}...")


### PR DESCRIPTION
The four workflow failures since Jul 17 evening share one cause: PR #18 added post_metrics_recent.csv to package_release.py's collection glob, but the same scan loop parses every non-streamed file with json.load to compute stats, so packaging crashed with JSONDecodeError before any release, prune, or Zenodo step could run. CSV files are now counted by line and packaged without JSON parsing.

Verified against a synthetic data directory (JSON plus CSV: correct counts, no parse error). Impact of the broken cycles: crawling and Hugging Face uploads continued (they do not depend on the zip), no GitHub release or Zenodo daily was produced since Jul 17, and the retention prune step never ran while broken. The next scheduled run packages normally and publishes the missed daily; crawl content self-heals since collection is incremental from the restored state.